### PR TITLE
chore(ci): make Chromatic exit 0 on visual changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -34,7 +34,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           buildScriptName: build-storybook
-          exitZeroOnChanges: false
+          exitZeroOnChanges: true
           onlyChanged: true
           diffThreshold: 0.06
           diffIncludeAntiAliasing: true


### PR DESCRIPTION
Sets exitZeroOnChanges: true so visual diffs no longer fail CI. Baseline-detection step still runs.