### PR TITLE
chore(tooling): add snapshot backup script

### DIFF
--- a/VISUAL_WORKFLOW.md
+++ b/VISUAL_WORKFLOW.md
@@ -50,7 +50,7 @@ snapshots/
 ### 1. Before Making Visual Changes
 ```bash
 # Always backup current snapshots
-npm run snapshots backup
+npm run snapshots        # backup current snapshots
 
 # Verify current state
 npm run test:visual:quick
@@ -78,7 +78,7 @@ npx playwright test tests/visual-integrity.spec.ts --update-snapshots
 On major milestones:
 ```bash
 # Create dated archive
-npm run snapshots backup
+npm run snapshots        # backup current snapshots
 
 # Archive will be created at:
 # snapshots/archive/YYYY-MM-DD/
@@ -154,7 +154,7 @@ Include:
 Before any deployment:
 
 - [ ] All visual tests passing (`npm run test:visual:all`)
-- [ ] Snapshots backed up (`npm run snapshots backup`)
+- [ ] Snapshots backed up (`npm run snapshots        # backup current snapshots`)
 - [ ] Changes documented in commit/PR
 - [ ] Production tag created (`prod-visual-lock-YYYY-MM-DD`)
 - [ ] Archive created for milestone releases

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "chromatic": "chromatic --exit-zero-on-changes",
-    "compare-baseline": "node --experimental-modules tools/compare/compare-baseline.mjs"
+    "compare-baseline": "node --experimental-modules tools/compare/compare-baseline.mjs",
+    "snapshots": "node ./scripts/snapshots.js"
   },
   "engines": {
     "node": ">=20.x"

--- a/scripts/snapshots.js
+++ b/scripts/snapshots.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Archives current Playwright or Chromatic snapshot directories
+ * into snapshots/archive/YYYY-MM-DD/
+ */
+const { execSync } = require('child_process');
+const { existsSync } = require('fs');
+
+const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+const dest = `snapshots/archive/${today}`;
+const src = 'tests/**/*-snapshots'; // adjust if needed
+
+// create target directory
+execSync(`mkdir -p ${dest}`, { stdio: 'inherit' });
+
+// copy snapshots if they exist
+if (existsSync('tests')) {
+  try {
+    // Find all snapshot directories
+    const snapshotDirs = execSync('find tests -name "*-snapshots" -type d', {
+      encoding: 'utf8',
+    })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+
+    if (snapshotDirs.length > 0) {
+      // Copy each directory
+      snapshotDirs.forEach((dir) => {
+        execSync(`cp -R ${dir} ${dest}/`, { stdio: 'inherit' });
+      });
+      console.log(`📸  Snapshots archived → ${dest}/`);
+      console.log(`   Archived ${snapshotDirs.length} snapshot directories`);
+    } else {
+      console.warn('⚠️  No snapshot directories found.');
+    }
+  } catch (error) {
+    console.warn('⚠️  Error archiving snapshots:', error.message);
+  }
+} else {
+  console.warn('⚠️  No tests directory found.');
+}


### PR DESCRIPTION
Adds npm run snapshots to archive visual-test snapshots into snapshots/archive/YYYY-MM-DD/